### PR TITLE
Fixed issue with warning Node no longer exists when offers are not prese...

### DIFF
--- a/src/BolOpenApi/Factory/ModelFactory.php
+++ b/src/BolOpenApi/Factory/ModelFactory.php
@@ -198,6 +198,11 @@ class ModelFactory
     public function createOffers(\SimpleXMLElement $xmlElement)
     {
         $offers = new Offers();
+
+        if (!isset($xmlElement) || $xmlElement->count() <= 0) {
+            return $offers;
+        }
+
         foreach ($xmlElement->children() as $child) {
             if ($child->getName() == 'Offer') {
                 $offers->addOffer($this->createOffer($child));


### PR DESCRIPTION
The following call to the Bol.com API returned a response with a result which contained no offers.

/openapi/services/rest/catalog/v3/searchresults?offset=0&nrProducts=5&sortingAscending=true&includeProducts=true&includeCategories=true&includeRefinements=true&term=hermans

This resulted in a PHP warning in the createOffers method. 

 Warning: BolOpenApi\Factory\ModelFactory::createOffers() [<a href='bolopenapi\factory\modelfactory.createoffers'>bolopenapi\factory\modelfactory.createoffers</a>]: Node no longer exists in /home/vagrant/vhosts/wordpress/wp-content/plugins/bolcom-partnerprogramma-wordpress-plugin/vendor/netvlies/bol-openapi-php-sdk/src/BolOpenApi/Factory/ModelFactory.php on line 205

I built in a check to prevent this warning.
